### PR TITLE
Revert to `trimLeft`, `trimRight`

### DIFF
--- a/lib/remark-smart-word-wrap.js
+++ b/lib/remark-smart-word-wrap.js
@@ -130,7 +130,7 @@ export default function attacher(options) {
       if (currentLine.length > 0) {
         currentLine[currentLine.length - 1] = currentLine[
           currentLine.length - 1
-        ].trimEnd();
+        ].trimRight();
       }
     }
 
@@ -159,14 +159,14 @@ export default function attacher(options) {
         SENTENCE_BREAKS && sentenceEnded && position >= SENTENCE_MIN_MARGIN;
       if (
         breakAllowed &&
-        (doSentenceBreak || position + word.trimEnd().length + 1 >= width)
+        (doSentenceBreak || position + word.trimRight().length + 1 >= width)
       ) {
         const didBreak = breakLine(isPlain);
         if (word === ' ') {
           return;
         }
 
-        currentLine.push(didBreak ? word.trimStart() : word);
+        currentLine.push(didBreak ? word.trimLeft() : word);
       } else {
         currentLine.push(word);
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "prettier": true,
     "esnext": false,
     "rules": {
-      "unicorn/string-content": "off"
+      "unicorn/string-content": "off",
+      "unicorn/prefer-trim-start-end": "off"
     }
   },
   "atomTestRunner": "atom-tap-test-runner",


### PR DESCRIPTION
If Atom cannot be upgraded, then maybe this’ll be good.